### PR TITLE
Add an assistant installation script, and revise the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,17 @@ these commands, one previews the current document and will watch the associated
 file for future changes, the other previews the current selection using a
 temporary file. The latter will not update automatically.
 
-### Sublime Text 2
+### Sublime Text
 
-Copy the `Marked 2.sublime-build1` file to `~/Library/Application Support/Sublime Text 2/Packages/User/`.
+Copy the `Marked 2.sublime-build` file to `~/Library/Application Support/Sublime Text 3/Packages/User/`.
 It will show up in the "Build Systems" section of the **Tools** menu in Sublime.
 When selected, pressing `Command-B` will open the current file in Marked for
 preview. Once opened, changes to the file will be tracked automatically by
 Marked.
+
+(This extension will also work with Sublime Text 2. Just copy
+`Marked 2.sublime-build` to
+`~/Library/Application Support/Sublime Text 2/Packages/User/`.)
 
 ### Vim
 
@@ -78,7 +82,7 @@ you have configured your emacs startup):
  3. Copy `dot.emacs.txt` to `~/.emacs.d/marked2.el` and ensure it is loaded by `~/.emacs.d/init.el`
  
 See
-[http://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html](http://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html)
+[The Emacs Initialization File](http://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html)
 for more information about emacs startup.
 
 Once installed, restart Emacs. Press `<Control>-C m` to preview the file

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ the original version of Marked, you will need to download [Marked Bonus Pack
 
 ## Installation and Usage
 
-Note that for some of the installation targets listed below --- specifically
-__Services__, __BBEdit__, __Sublime Text__, and __iA Writer__ --- you can use
+Note that for some of the installation targets listed below — specifically
+__Services__, __BBEdit__, __Sublime Text__, and __iA Writer__ — you can use
 the provided
 [install](./install) script.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ the original version of Marked, you will need to download [Marked Bonus Pack
 
 ## Installation and Usage
 
+Note that for some of the installation targets listed below --- specifically
+__Services__, __BBEdit__, __Sublime Text__, and __iA Writer__ --- you can use
+the provided
+[install](./install) script.
+
 ### Services
 
 Put the Services in `~/Library/Services`, where `~` is your user's home folder.

--- a/install
+++ b/install
@@ -1,0 +1,57 @@
+#! /usr/bin/env bash
+
+services() {
+    cp -r Services/* $HOME/Library/Services
+}
+
+bbedit() {
+    cp "BBEdit/Open in Marked.applescript" \
+       "$HOME/Library/Application Support/BBEdit/Scripts/"
+}
+
+st2() {
+    cp "Marked 2.sublime-build" \
+       "$HOME/Library/Application Support/Sublime Text 2/Packages/User"
+}
+
+st3() {
+    cp "Marked 2.sublime-build" \
+       "$HOME/Library/Application Support/Sublime Text 3/Packages/User"
+}
+
+iawriter() {
+    cp "iAWriter/Open in Marked.applescript" \
+       "$HOME/Library/Scripts/Applications/iA Writer/"
+}
+
+# TODO:
+#   Check for and/or ensure the existence of target directories.
+#   Add vim support.
+#   Add emacs support.
+
+if [[ -z $@ ]]
+then
+    cat << EOF
+This scriptlet automates installing *some* elements of the Marked
+bonus pack. It currently supports the targets listed below, using the
+corresponding keywords:
+
+    Target            Keyword
+    --------------    --------
+    Services          services
+    BBEdit.           bbedit
+    Sublime Text 2    st2
+    Sublime Text 3    st3
+    iA Writer.        iawriter
+
+Invoke it with one or more of the keywords as arguments, e.g.
+
+    ./install services st3
+EOF
+else
+    for i in $@
+    do
+        echo "Installing $i"
+        $i
+    done
+fi


### PR DESCRIPTION
Instead of having to assemble their own `cp` command from snippets copied out of README.md, users can just call `install`, specifying their desired installation targets. Note that `install` presently only handles the super-simple cases. It doesn’t check for the existence of the target directories, let alone try to create them, but is nevertheless, IMHO, useful.

The original commit comment said, “Also fix a one-character typo in README.md.” That’s actually a lie.

- It doesn’t just remove the spurious '1' from 'Marked 2.sublime-build1'; it also switches to Sublime Text 3, now the official release, as the principal target, retaining mention of Sublime Text 2 at the end of the section.
- It also changes the text of the link to “The Emacs Initialization File” from a raw URL to the page title.